### PR TITLE
Correctly match kernel

### DIFF
--- a/agents/plugins/yum
+++ b/agents/plugins/yum
@@ -52,7 +52,7 @@ then
         LATEST_KERNEL=$(yum -q -C --noplugins list installed kernel | grep "\." | tail -n1 | awk '{print $2};')
         RUNNING_KERNEL=$(cat /proc/version | awk '{print $3}')
         
-        if [[ "$RUNNING_KERNEL" == "$LATEST_KERNEL"* ]]
+        if [[ "$RUNNING_KERNEL" =~ "$LATEST_KERNEL"* ]]
         then
             BOOT_REQUIRED="no"
         else


### PR DESCRIPTION
When comparing the latest version of the kernel installed with the latest kernel the match was not correct

e.g. the running kernel gives 3.10.0-327.28.3.el7.x86_64 and the version as shown in yum is 3.10.0-327.28.3.el7