### PR TITLE
Enable WATO rule override of state when reboot is required

### DIFF
--- a/checkman/yum
+++ b/checkman/yum
@@ -9,6 +9,7 @@ description:
  into the {plugins} directory of your agent.
 
  The check gets critical if kernel updates require a reboot.
+ This state can be overriden via a WATO rule.
  It gets warning state if there are any updates available.
 
 inventory:

--- a/checks/yum
+++ b/checks/yum
@@ -3,6 +3,7 @@
 # Check_MK YUM Plugin - Check for upgradeable packages.
 #
 # Copyright 2015, Henri Wahl <h.wahl@ifw-dresden.de>
+# Copyright 2018, Moritz Schlarb <schlarbm@uni-mainz.de>
 #
 # Based on:
 #
@@ -32,12 +33,16 @@
 # 4
 
 
+factory_settings["yum_default_levels"] = {
+    "reboot_req" : 2,
+}
+
 def inventory_yum(checkname, info):
     if len(info) > 0:
-        return [(None, None)]
+        return [(None, {})]
 
 # the check function
-def check_yum(_no_item, _no_params, info):
+def check_yum(_no_item, params, info):
     level        = 0
     msg          = ''
     reboot_req   = 'no'
@@ -65,7 +70,7 @@ def check_yum(_no_item, _no_params, info):
             msg = '%s update%s available' % (packages, s) 
 
     if (reboot_req == "yes") and (level == 0):
-        level = 2 
+        level = params["reboot_req"]
         msg = "reboot required"
 
     if level > 0:
@@ -79,4 +84,5 @@ check_info["yum"] = {
         "has_perfdata"              : False,
         "inventory_function"        : inventory_yum,
         "group"                     : "yum",
+        "default_levels_variable"   : "yum_default_levels",
 }

--- a/web/plugins/wato/yum_check_parameters.py
+++ b/web/plugins/wato/yum_check_parameters.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- encoding: utf-8; py-indent-offset: 4 -*-
 #
+# 2018 Moritz Schlarb <schlarbm@uni-mainz.de>
 # 2015 Henri Wahl <h.wahl@ifw-dresden.de>
 # 2013 Karsten Schoeke karsten.schoeke@geobasis-bb.de
 
@@ -12,6 +13,15 @@ register_check_parameters(
     subgroup_os,
     "yum",
     _("YUM Update check"),
-        None,
-        None, None
+    Dictionary(
+        elements = [
+            ("reboot_req",
+                MonitoringState(
+                    title = _("State when a reboot is required"),
+                    default_value = 2,
+            )),
+        ]
+    ),
+    None,
+    match_type = "dict",
 )


### PR DESCRIPTION
Hi Henri,

would you mind merging this change and uploading a new version of the mkp?

Regards,
Moritz