### PR TITLE
Update yum

### DIFF
--- a/agents/plugins/yum
+++ b/agents/plugins/yum
@@ -50,7 +50,7 @@ if [ "$YUM_CURRENT" != "$YUM_CACHED" ] || [ ! -s $MK_VARDIR/cache/yum_check.cach
 then
     if [ -z $(pgrep -f "python /usr/bin/yum") ]; then
         LATEST_KERNEL=$(yum -q -C --noplugins list installed | egrep "^(vz)?kernel(|-uek)\." | grep "\." | tail -n1 | awk '{print $2};')
-        RUNNING_KERNEL=$(cat /proc/version | awk '{print $3}')
+        RUNNING_KERNEL=$(cat /proc/version | awk '{print $3}' | sed 's/.x86_64//g')
         
         if [[ "$RUNNING_KERNEL" == "$LATEST_KERNEL"* ]]
         then


### PR DESCRIPTION
https://github.com/HenriWahl/checkmk-agent-plugin-yum/issues/12#issuecomment-461317564

52:        LATEST_KERNEL=$(yum -q -C --noplugins list installed | egrep "^(vz)?kernel(|-uek)\." | grep "\." | tail -n1 | awk '{print $2};')
53:        RUNNING_KERNEL=$(cat /proc/version | awk '{print $3}' )

Zeile 52 liefert bei mir:
3.10.0-957.10.1.el7
Zeile 53:
3.10.0-957.10.1.el7.x86_64
habe noch ein sed angehängt um das  .x86_64  zu entfernen:
53:        RUNNING_KERNEL=$(cat /proc/version | awk '{print $3}' | sed 's/.x86_64//g')

damit läufts wieder.

Bin neu bei github - habe also keine Ahnung, ob ich das jetzt richtig gemacht hab mit fork usw. aber ich denke, das Ergebnis steht im Vordergrund.

Gruß!