### PR TITLE
consider elrepo kernel variants lt / ml

### DIFF
--- a/agents/plugins/yum
+++ b/agents/plugins/yum
@@ -59,7 +59,7 @@ YUM_CACHED="$(cat $YUM_CACHE_FILE)"
 if [ "$YUM_CURRENT" != "$YUM_CACHED" ] || [ ! -s $YUM_CACHE_FILE ]
 then
     if [ -z $(pgrep -f "python /usr/bin/yum") ]; then
-        LATEST_KERNEL=$(yum -q -C --noplugins --debuglevel 0 list installed | egrep "^(vz)?kernel(|-uek)\." | grep "\." | tail -n1 | awk '{print $2};')
+        LATEST_KERNEL=$(yum -q -C --noplugins --debuglevel 0 list installed | egrep "^(vz)?kernel(|-(uek|ml|lt))\." | grep "\." | tail -n1 | awk '{print $2};')
         RUNNING_KERNEL=$(cat /proc/version | awk '{print $3}' | sed 's/.x86_64//g')
         
         if [[ "$RUNNING_KERNEL" == "$LATEST_KERNEL"* ]]


### PR DESCRIPTION
Update for the agent plugin to support kernel packages from "elrepo-kernel" repository. This repository provides kernel packages from the mainline branch and the long term support branch 

* kernel-ml.x86_64 (see: http://elrepo.org/tiki/kernel-ml)
* kernel-lt.x86_64 (see: http://elrepo.org/tiki/kernel-lt)

Otherwise, the latest kernel package will not be detected correctly and the agent plugin states a "reboot required" error.