### PR TITLE
Add opt. Statuschange based on last updatedate

### DIFF
--- a/agents/plugins/yum
+++ b/agents/plugins/yum
@@ -10,6 +10,8 @@ UPDATES=0
 SECURITY_UPDATES=0
 CACHE_RESULT_CHECK=$MK_VARDIR/cache/yum_result.cache
 CACHE_YUM_UPDATE=$MK_VARDIR/cache/yum_update.cache
+LAST_UPDATE_TIMESTAMP=-1
+
 
 # get current yum state - use cache directory contents as fingerprint
 YUM_CURRENT="$(ls -lR /var/cache/yum/ || ls -lR /var/cache/dnf/)"
@@ -86,9 +88,15 @@ then
             SECURITY_UPDATES="-2"
     fi
 
+    # Check last time of installed Updates from yum history
+    LAST_UPDATE_TIMESTAMP=$(/usr/bin/yum -C --quiet --noplugins history | awk '{if(NR>2)print}' | grep  ' U \|Upgrade' | cut -d '|' -f3  | head -n 1 | date -f - +"%s" || echo "-1")
+
+
     echo $BOOT_REQUIRED
     echo $UPDATES
     echo $SECURITY_UPDATES
+    echo $LAST_UPDATE_TIMESTAMP
+
     # cache check yum
     # check if cached check already exists and is nothing but a file
     if [ -f $CACHE_YUM_UPDATE ] || [ ! -L $CACHE_YUM_UPDATE ]; then
@@ -105,6 +113,7 @@ then
         echo $BOOT_REQUIRED > $CACHE_RESULT_CHECK
         echo $UPDATES >> $CACHE_RESULT_CHECK
         echo $SECURITY_UPDATES >> $CACHE_RESULT_CHECK
+        echo $LAST_UPDATE_TIMESTAMP >> $CACHE_RESULT_CHECK
     else
         # something is wrong here...
         echo "invalid check result cache file"

--- a/checks/yum
+++ b/checks/yum
@@ -5,7 +5,7 @@
 # Copyright 2015, Henri Wahl <h.wahl@ifw-dresden.de>
 # Copyright 2018, Moritz Schlarb <schlarbm@uni-mainz.de>
 # Copyright 2021, Marco Lenhardt <marco.lenhardt@ontec.at>
-#
+# Copyright 2021, Henrik Gießel <henrik.giessel@yahoo.de>
 # Based on:
 #
 # Check_MK APT-NG Plugin - Check for upgradeable packages.
@@ -33,12 +33,17 @@
 # yes
 # 32
 # 4
+# 1626252300
 
+from datetime import datetime
+from time import time
 
 factory_settings["yum_default_levels"] = {
     "reboot_req" : 2,
     "normal": 1,
     "security": 2,
+    "last_update_state": 0,
+    "last_update_time_diff": (60*24*60*60),
 }
 
 def inventory_yum(info):
@@ -71,6 +76,11 @@ def check_yum(_no_item, params, info):
         except:
             security_packages = -1
             
+        try:
+            last_update_timestamp = int(info[3][0])
+        except:
+            last_update_timestamp = -1
+
         if packages < 0:
             level = 3
             yield level, 'No package information available'
@@ -84,7 +94,25 @@ def check_yum(_no_item, params, info):
         if security_packages > 0:
             level = params["security"]
             yield level, "%d security updates available" % security_packages, [("security_updates", security_packages)]
+        
+        if last_update_timestamp < 0:
+            level = params["last_update_state"]
+            yield level, "%d Time of last update could not be found" % last_update_timestamp, [("last_update_timestamp", last_update_timestamp)]
+        
+        elif last_update_timestamp > 0:
+            level = params["last_update_state"]
+            last_update_timestamp_diff = params["last_update_time_diff"]
+            current_timestamp=int(time())
+
+            if current_timestamp - last_update_timestamp < last_update_timestamp_diff:
+                yield 0, "Last Update was run at %s"  % datetime.fromtimestamp(last_update_timestamp)
+
+            elif current_timestamp - last_update_timestamp > last_update_timestamp_diff and packages == 0:
+                yield 0, "Last Update was too long ago at %s but there are no pending updates"  % datetime.fromtimestamp(last_update_timestamp)
             
+            else:
+                yield level, "Last Update was too long ago at %s and there are pending updates" % datetime.fromtimestamp(last_update_timestamp)
+
 
     if (reboot_req == "yes"):
         # fallback for < 2.0.6

--- a/web/plugins/wato/yum_check_parameters.py
+++ b/web/plugins/wato/yum_check_parameters.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- encoding: utf-8; py-indent-offset: 4 -*-
 #
+# 2021 Henrik Gießel <henrik.giessel@yahoo.de>
 # 2018 Moritz Schlarb <schlarbm@uni-mainz.de>
 # 2015 Henri Wahl <h.wahl@ifw-dresden.de>
 # 2013 Karsten Schoeke karsten.schoeke@geobasis-bb.de
@@ -29,6 +30,16 @@ register_check_parameters(
                 MonitoringState(
                     title = _("State when security updates are available"),
                     default_value = 2,
+            )),
+            ("last_update_time_diff",
+                Age(
+                    title = _("Max Time since last last run update (Default 60 Days)"),
+                    default_value = (60*24*60*60),        
+            )),
+            ("last_update_state",
+                MonitoringState(
+                    title = _("Change State based on last run update (default OK)"),
+                    default_value = 0,
             )),
         ]
     ),


### PR DESCRIPTION
A new feature is added to find systems that weren't patched for a defined time. 
The agent output will now have a forth element. Now it will look like:
```
# <<<yum>>>
# yes
# 32
# 4
# 1626252300
```

It is a unix timestamp that is generated by the youngest entry from "yum history" command. The timestamp will be compared to a
a newly added entry in WATO that can be configured by the user.

The plugin will now show following new behavior:
- when last upgrade was less then defined time ago, then the check stays "OK"
- when last upgrade was more then defined time ago BUT there are no patches available, then the check stays "OK"
- when last upgrade was more then defined time ago AND there is at is at least 1 normal patch, then status shall change to the defined status.
- If the timestamp could not be determined, then the check will change to defined status

The default status level in WATO is "OK" so the plugin will not change behaviour when the feature 
is not explicitly used. The default timerange is 60 days. 

It was tested on CentOS8 host and CheckMK 2.0.0.p5