### PR TITLE
Corrected test for updating cache

### DIFF
--- a/agents/plugins/yum
+++ b/agents/plugins/yum
@@ -56,7 +56,8 @@ fi
 echo "<<<yum>>>"
 
 # compare current and cached yum information
-if [ "$YUM_CURRENT" != "$YUM_CACHED)" ] && [ ! -s $CACHE_RESULT_CHECK ]
+# Update cached data if YUM fingerprint has changed OR machine has recently rebooted.
+if [ "$YUM_CURRENT" != "$YUM_CACHED" ] || [ ! -s $CACHE_RESULT_CHECK ]
 then
     count=0
         while [ -n "$(pgrep -f "python /usr/bin/yum")" ]; do


### PR DESCRIPTION
Removed spurious ")" from first clause so it's true only when current "fingerprint" and cached "fingerprint" actually differ.
OR instead of AND so that updates don't happen only in the first 120 seconds after the machine is rebooted.