### PR TITLE
This commit handles two Error Messages, that can occur

### DIFF
--- a/agents/plugins/yum
+++ b/agents/plugins/yum
@@ -15,7 +15,7 @@ LAST_UPDATE_TIMESTAMP=-1
 
 
 # get current yum state - use cache directory contents as fingerprint
-YUM_CURRENT="$(ls -lR /var/cache/{yum,dnf}/)"
+YUM_CURRENT="$(ls -lR /var/cache/{yum,dnf}/ 2>/dev/null)"
 
 # check if cached listing of /var/cache/yum already exists - create empty one otherwise
 if [ ! -e $CACHE_YUM_UPDATE ]

--- a/checks/yum
+++ b/checks/yum
@@ -59,9 +59,15 @@ def check_yum(_no_item, params, info):
     security_packages = -1
     perfdata     = []
     
+    # Handle error message on blocking process
+    # "Tried to run yum for 30 secs but another yum instance was running"
+    if len(info) == 1 \
+       and "Tried to run yum for 30 secs but another yum instance was running" == " ".join(info[0]):
+        yield 3, "Tried to run yum for 30 secs but another yum instance was running"
+
     # Parse the agent output
     if len(info) > 0:
-        reboot_req   = info[0][0]
+        reboot_req = info[0][0]
         if not reboot_req in ('yes', 'no'):
             reboot_req = ''
         


### PR DESCRIPTION
These error messages are handled:

When /var/cache/yum is not available, for example rhel8.4, this plugin no longer produces a ls errorline in the previous agent section

When another process of dnf is running, the agent section can now be handled and the service no longer is vanished