### PR TITLE
Updated timeout waiting for security update checks

### DIFF
--- a/agents/plugins/yum
+++ b/agents/plugins/yum
@@ -97,7 +97,8 @@ then
     fi
     UPDATES=$(waitmax 25 /usr/bin/yum -C --noplugins --quiet list updates | grep "\." | cut -d' ' -f1 | wc -l || echo "-1")
     # check if --security is available
-    waitmax 10 /usr/bin/yum -C --noplugins --quiet --security list updates > /dev/null 2>&1
+    # Updated the timeout for the initial security list validation because it takes longer than 10 seconds on many machines
+    waitmax 25 /usr/bin/yum -C --noplugins --quiet --security list updates > /dev/null 2>&1
     if [ $? -eq 0 ]
     then
         SECURITY_UPDATES=$(waitmax 25 /usr/bin/yum -C --noplugins --quiet --security list updates | grep "\." | cut -d' ' -f1 | wc -l || echo "-1")


### PR DESCRIPTION
Updated the security update timeout (using waitmax) before the logic statement about whether the --security yum feature is enabled. The check was not completing on many servers due to the sheer number of security updates that are required to be processed by yum, and thus the plugin reported "-2" to the check. This gave false results in the check suggesting no updates were available when they are.