### PR TITLE
Incorrect logic assessment of security updates

### DIFF
--- a/lib/python3/cmk/base/plugins/agent_based/yum.py
+++ b/lib/python3/cmk/base/plugins/agent_based/yum.py
@@ -131,7 +131,7 @@ def check_yum(params: Dict[str, int], section: Section):
     # Check the status of the returned number of updates that are security updates including
 	# error condition and if there are no updates or the security updates check is not possible
     # First check if ANY updates were flagged as security updates and report the metric
-    if section.security_packages >= 0:
+    if section.security_packages > 0:
         yield Result(state=State(params.get("security", 0)), summary=f"{section.security_packages} security updates available")
         yield Metric(name="security_updates", value=section.security_packages)
     # If there are no updates available, report this


### PR DESCRIPTION
The script was double assessing the presence of 0 in the security updates. Have removed the >= to correct the situation where no updates are available, but the plugin would show "CRITICAL" when configured to show critical for update > 0