### PR TITLE
Update manual page to prevent errors

### DIFF
--- a/checkman/yum
+++ b/checkman/yum
@@ -1,6 +1,7 @@
 title: Check for updates via yum
 agents: linux
 author: Henri Wahl <h.wahl@ifw-dresden.de>, based on work of Karsten Scgoeke <karsten.schoeke@geobasis-bb.de>, Stefan Schlesinger <sts@ono.at>
+catalog: generic
 license: GPL
 distribution: check_mk
 description:


### PR DESCRIPTION
Added a new "catalog" section to the man page to prevent errors when trying to view the yum plugin manual in later versions of check mk.