### PR TITLE
Show Security Packages, fix distro detect, last update timestamp and aarch64 support

### DIFF
--- a/agents/plugins/yum
+++ b/agents/plugins/yum
@@ -17,8 +17,32 @@ LAST_UPDATE_TIMESTAMP=-1
 
 # Check which distribution and major version we are running
 if [ -f "/etc/os-release" ]; then
-  MAJOR_VERSION=$(awk -F'=' '/^VERSION_ID=/ {gsub(/"/,"",$2); split($2,a,"."); print a[1]}' /etc/os-release)
-  DISTRO_ID=$(awk -F'=' '/^ID=/ {gsub(/"/,"",$2); print $2}' /etc/os-release)
+  # Read required fields
+  . /etc/os-release
+  
+  # Extract major version
+  MAJOR_VERSION=$(echo "$VERSION_ID" | cut -d. -f1)
+
+  # Normalize DISTRO_ID using ID_LIKE if available
+  if echo "$ID_LIKE" | grep -qw "rhel"; then
+    DISTRO_ID="rhel"
+  else
+    DISTRO_ID="$ID"
+  fi
+elif [ -f "/etc/redhat-release" ]; then
+  # EL6 or other legacy RHEL-like systems
+  RELEASE_TEXT=$(cat /etc/redhat-release)
+
+  if echo "$RELEASE_TEXT" | grep -qi "CentOS"; then
+    DISTRO_ID="centos"
+  elif echo "$RELEASE_TEXT" | grep -qi "Red Hat"; then
+    DISTRO_ID="rhel"
+  else
+    DISTRO_ID="unknown"
+  fi
+
+  # Extract major version number (e.g., "6" from "release 6.10")
+  MAJOR_VERSION=$(echo "$RELEASE_TEXT" | grep -oE 'release [0-9]+' | awk '{print $2}')
 else
   MAJOR_VERSION=0
   DISTRO_ID="unknown"
@@ -186,12 +210,16 @@ then
     if [ "$PKG_MGR" = "dnf5" ]; then
         # dnf5 has different history output format - look for upgrade/update actions, not download
         LAST_UPDATE_TIMESTAMP=$(dnf5 history list 2>/dev/null | awk '/upgrade --refresh|update[^-]|update$/ {print $5" "$6}' | head -n1 | date -f - +"%s" 2>/dev/null || echo "-1")
-    elif [ "$DISTRO_ID" = "fedora" ] || [ "$DISTRO_ID" = "centos" -a "$MAJOR_VERSION" -ge 8 ] || [ "$DISTRO_ID" = "rhel" -a "$MAJOR_VERSION" -ge 8 ]; then
-        # Modern dnf/yum with different history format
-        LAST_UPDATE_TIMESTAMP=$($PKG_MGR -C --quiet --noplugins history list 2>/dev/null | awk '{if(NR>2)print}' | grep -E ' U | Upgrade| Update' | head -n1 | awk '{print $3}' | date -f - +"%s" 2>/dev/null || echo "-1")
     else
-        # Legacy yum (CentOS/RHEL 6-7)
-        LAST_UPDATE_TIMESTAMP=$(yum -C --quiet --noplugins history list all 2>/dev/null | awk '{if(NR>2)print}' | grep -E ' U | Upgrade| Update' | cut -d '|' -f3 | head -n1 | date -f - +"%s" 2>/dev/null || echo "-1")
+        HISTORY_CMD="$PKG_MGR -C --quiet --noplugins history list"
+
+        # Use 'all' for RHEL/CentOS 7 or below
+        if { [ "$DISTRO_ID" = "rhel" ] || [ "$DISTRO_ID" = "centos" ]; } && [ "$MAJOR_VERSION" -le 7 ]; then
+            HISTORY_CMD="$HISTORY_CMD all"
+        fi
+
+        # Run the history command and extract the last update timestamp
+        LAST_UPDATE_TIMESTAMP=$($HISTORY_CMD | awk '{if(NR>2)print}' | grep -E ' U | Upgrade| Update' | head -n1 | awk -F'|' '{print $3}' | date -f - +"%s" 2>/dev/null || echo "-1")
     fi
 
     # Add check in case this is a brand new built machine
@@ -213,7 +241,7 @@ then
         echo "ERROR: invalid check cache file"
         exit 2
     fi
-    
+
     # cache check results
     if [ -f "$CACHE_RESULT_CHECK" ] || [ ! -L "$CACHE_RESULT_CHECK" ]
     then

--- a/agents/plugins/yum
+++ b/agents/plugins/yum
@@ -147,33 +147,39 @@ then
 
     # Count available updates - different commands for different package managers
     if [ "$PKG_MGR" = "dnf5" ]; then
-        UPDATES=$(waitmax 25 dnf5 list --upgrades 2>/dev/null | grep -E "^[a-zA-Z]" | wc -l || echo "-1")
+        UPDATES=$(timeout 25s dnf5 list --upgrades 2>/dev/null | grep -E "^[a-zA-Z]" | wc -l || echo "-1")
     else
-        UPDATES=$(waitmax 25 $PKG_MGR -C --noplugins --quiet list updates 2>/dev/null | grep "\." | cut -d' ' -f1 | wc -l || echo "-1")
+        UPDATES=$(timeout 25s $PKG_MGR -C --noplugins --quiet list updates 2>/dev/null | grep "\." | cut -d' ' -f1 | wc -l || echo "-1")
     fi
 
     # Check for security updates if supported
     if [ $SECURITY_SUPPORTED -eq 1 ]; then
         if [ "$PKG_MGR" = "dnf5" ]; then
             # dnf5 uses different command for security updates
-            SECURITY_UPDATES=$(waitmax 25 dnf5 -C --quiet check-upgrade --security 2>/dev/null | grep -E "^[a-zA-Z0-9]" | wc -l || echo "-1")
+            SECURITY_OUTPUT=$(timeout 25s dnf5 -C --quiet check-upgrade --security 2>/dev/null)
+            SECURITY_UPDATES=$(echo "$SECURITY_OUTPUT" | grep -E "^[a-zA-Z0-9]" | wc -l || echo "-1")
+            SECURITY_UPDATES_LIST=$(echo "$SECURITY_OUTPUT" | grep -E "^[a-zA-Z0-9]" | awk '{print $1}' | sed 's/\.[^.]*$//' | paste -sd, -)
         else
             # Test if --security is available for traditional yum/dnf
-            waitmax 25 $PKG_MGR -C --noplugins --quiet --security list updates > /dev/null 2>&1
+            timeout 25s $PKG_MGR -C --noplugins --quiet --security list updates > /dev/null 2>&1
             if [ $? -eq 0 ]; then
                 if [ "$PKG_MGR" = "dnf" ]; then
-                    SECURITY_UPDATES=$(waitmax 25 dnf -C --noplugins --quiet --security list updates 2>/dev/null | grep "\." | cut -d' ' -f1 | wc -l || echo "-1")
+                    SECURITY_OUTPUT=$(timeout 25s dnf -C --noplugins --quiet --security list updates 2>/dev/null)
                 else
-                    SECURITY_UPDATES=$(waitmax 25 yum -C --noplugins --quiet --security list updates 2>/dev/null | grep "\." | cut -d' ' -f1 | wc -l || echo "-1")
+                    SECURITY_OUTPUT=$(timeout 25s yum -C --noplugins --quiet --security list updates 2>/dev/null)
                 fi
+                SECURITY_UPDATES=$(echo "$SECURITY_OUTPUT" | grep "\." | cut -d' ' -f1 | wc -l || echo "-1")
+                SECURITY_UPDATES_LIST=$(echo "$SECURITY_OUTPUT" | grep "\." | cut -d' ' -f1 | sed 's/\.[^.]*$//' |  paste -sd, -)
             else
                 # --security not supported with this version
                 SECURITY_UPDATES="-2"
+                SECURITY_UPDATES_LIST=""
             fi
         fi
     else
         # Package manager doesn't support security updates
         SECURITY_UPDATES="-2"
+        SECURITY_UPDATES_LIST=""
     fi
 
     # Check last time of installed Updates from history
@@ -195,7 +201,7 @@ then
 
     echo "$BOOT_REQUIRED"
     echo "$UPDATES"
-    echo "$SECURITY_UPDATES"
+    echo "$SECURITY_UPDATES $SECURITY_UPDATES_LIST"
     echo "$LAST_UPDATE_TIMESTAMP"
 
     # cache check yum/dnf
@@ -213,7 +219,7 @@ then
     then
         echo "$BOOT_REQUIRED" > "$CACHE_RESULT_CHECK"
         echo "$UPDATES" >> "$CACHE_RESULT_CHECK"
-        echo "$SECURITY_UPDATES" >> "$CACHE_RESULT_CHECK"
+        echo "$SECURITY_UPDATES $SECURITY_UPDATES_LIST" >> "$CACHE_RESULT_CHECK"
         echo "$LAST_UPDATE_TIMESTAMP" >> "$CACHE_RESULT_CHECK"
     else
         # something is wrong here...

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM checkmk/check-mk-raw:2.3.0-latest
+FROM checkmk/check-mk-raw:2.4.0-latest
 LABEL maintainer=henri@nagstamon.de
 
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This PR simply adds a list of packages for security updates, so you can see what packages need updating to more clearly evaluate the severity of the updates.

```
11 normal updates available
2 security updates available (sudo,sudo-python-plugin)
Last update was at 2025-07-20 16:03:00
```

You will also notice I changed `maxwait` to `timeout` because checkmk only compile `maxwait` for x86_64, so it can't be used on aarch64. sadly there's a few binaries like this in the CheckMK raw agent. 

Edit: After some more testing, I fixed a few other bugs around detecting `Last update` and support for AlmaLinux like derivatives