### PR TITLE
Fix check_default_parameters formatting

### DIFF
--- a/lib/python3/cmk_addons/plugins/yum/agent_based/yum.py
+++ b/lib/python3/cmk_addons/plugins/yum/agent_based/yum.py
@@ -207,8 +207,8 @@ check_plugin_yum = CheckPlugin(
     check_ruleset_name="yum",
     check_default_parameters={
         "reboot_req": 2,
-        "normal": {"fixed": (1, 10)},
-        "security": {"fixed": (1, 1)},
+        "normal": ("fixed", (1, 10)),
+        "security": ("fixed", (1, 1)),
         "last_update_state": 1,
         "last_update_time_diff": 60,
     },


### PR DESCRIPTION
Fixes issue reported here https://github.com/HenriWahl/checkmk-agent-plugin-yum/commit/1ac38400eb2cfa4a3c414321a1c3cdf5046e1a4f#commitcomment-166330472

I must of gotten some code changes mixed up when I was fixing it, but works now.