### PR TITLE
fix(yum): keep int defaults when string_table is shorter than 4 lines

### DIFF
--- a/mkp/local/lib/python3/cmk_addons/plugins/yum/agent_based/yum.py
+++ b/mkp/local/lib/python3/cmk_addons/plugins/yum/agent_based/yum.py
@@ -93,11 +93,11 @@ def yum_parse(string_table: List[List[str]]) -> Section:
 
     return Section(
         reboot_required,
-        packages,
+        packages if packages is not None else -1,
         locked_packages_list,
-        security_packages,
+        security_packages if security_packages is not None else -1,
         security_packages_list,
-        last_update_timestamp)
+        last_update_timestamp if last_update_timestamp is not None else -1)
 
 
 agent_section_yum = AgentSection(


### PR DESCRIPTION
Closes #115.

When `string_table` has fewer than 4 lines, the `IndexError` branch leaves `packages`, `security_packages` and `last_update_timestamp` as `None`. Passed positionally into `Section(...)`, the `int = -1` defaults never engage, and `check_yum()` then dies on `< 0` / `>= 0` comparisons.

Fix: substitute `-1` for `None` at the call site so the int contract holds.